### PR TITLE
optionalField was not decoding at the fieldName

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -129,7 +129,7 @@ optionalField fieldName decoder =
             case decodeValue (field fieldName value) json of
                 Ok val ->
                     -- The field is present, so run the decoder on it.
-                    map Just decoder
+                    map Just (field fieldName decoder)
 
                 Err _ ->
                     -- The field was missing, which is fine!


### PR DESCRIPTION
If the field existed, optionalField would try to decode the entire object containing the field, not just the field's value.