### PR TITLE
Add `doubleEncoded` decoder

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -23,6 +23,9 @@ module Json.Decode.Extra exposing (date, andMap, (|:), sequence, set, dict2, wit
 # Result
 @docs fromResult
 
+# Json (double-encoded strings)
+@docs doubleEncoded
+
 -}
 
 import Json.Decode exposing (..)
@@ -204,3 +207,19 @@ fromResult result =
 
         Err errorMessage ->
             fail errorMessage
+
+{-| Extract a JSON-encoded string field
+
+"Yo dawg, I heard you like JSON..."
+
+If someone has put JSON in your JSON (perhaps a JSON log entry, encoded
+as a string) this is the function you're looking for. Give it a decoder
+and it will return a new decoder that applies your decoder to a string
+field and yields the result (or fails if your decoder fails).
+
+    log: Decoder (List LogEntry)
+    log = list (doubleEncoded LogEntry)
+
+-}
+doubleEncoded : Decoder a -> Decoder a
+doubleEncoded decoder = string |> andThen (fromResult << decodeString decoder)


### PR DESCRIPTION
This decoder decodes a string field that contains a JSON-encoded string.

As outlined by @jamesmacaulay for me (thanks!) :+1:

We could alternately call this `json` or `jsonString` to indicate that the field contains JSON, which would be more consistent with other built-in decoders (`string`, `int`, `list`, etc.), but `doubleEncoded` seems nicely explicit in a context where everything is supposed to be JSON. I'm not sure which is clearer.

Also, I'm not sure if I got the documentation format right (I'm not familiar with it, so I just copied the format I saw on other methods)