### PR TITLE
Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+**Additions:**
+- `keys` allows extracting _only_ the keys from a JSON object
+
 ### 2.5.0
 
 **Additions:**

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -39,7 +39,7 @@ Examples assume the following imports:
 
 # List
 
-@docs collection, sequence, combine, indexedList
+@docs collection, sequence, combine, indexedList, keys
 
 
 # Set
@@ -290,6 +290,18 @@ indexedList indexedDecoder =
                     |> List.map indexedDecoder
                     |> sequence
             )
+
+
+{-| Get a list of the keys of the JSON object
+
+    decodeString keys "{ \"alice\": 42, \"bob\": 99 }"
+        == [ "alice", "bob" ]
+
+-}
+keys : Decoder (List String)
+keys =
+    keyValuePairs (succeed ())
+        |> map (List.map Tuple.first)
 
 
 {-| Transform a result into a decoder

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -296,6 +296,7 @@ indexedList indexedDecoder =
 
     decodeString keys "{ \"alice\": 42, \"bob\": 99 }"
         == [ "alice", "bob" ]
+    --> True
 
 -}
 keys : Decoder (List String)

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -292,7 +292,7 @@ indexedList indexedDecoder =
             )
 
 
-{-| Get a list of the keys of the JSON object
+{-| Get a list of the keys of a JSON object
 
     decodeString keys "{ \"alice\": 42, \"bob\": 99 }"
         == [ "alice", "bob" ]

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -9,6 +9,7 @@ module Json.Decode.Extra
         , doubleEncoded
         , fromResult
         , indexedList
+        , keys
         , optionalField
         , parseFloat
         , parseInt
@@ -294,15 +295,15 @@ indexedList indexedDecoder =
 
 {-| Get a list of the keys of a JSON object
 
-    decodeString keys "{ \"alice\": 42, \"bob\": 99 }"
-        == [ "alice", "bob" ]
-    --> True
+    """ { "alice": 42, "bob": 99 } """
+        |> decodeString keys
+    --> Ok [ "alice", "bob" ]
 
 -}
 keys : Decoder (List String)
 keys =
     keyValuePairs (succeed ())
-        |> map (List.map Tuple.first)
+        |> map (List.foldl (\( key, _ ) acc -> key :: acc) [])
 
 
 {-| Transform a result into a decoder


### PR DESCRIPTION
Here is a function to get the keys of a JSON object. It works just by using the core function `keyValuePairs` and then discards the values.

We wrote this up this function at my job, where we needed to decode a list of urls, that werent just stored as strings but `{ < urlType > : String }` where the `urlType` varied and it was the only information we cared about.