### PR TITLE
Add emptyObject

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -4,7 +4,7 @@ module Json.Decode.Extra exposing
     , when
     , collection, sequence, combine, indexedList, keys
     , set
-    , dict2
+    , dict2, emptyObject
     , withDefault, optionalField
     , fromResult
     , parseInt, parseFloat, doubleEncoded
@@ -40,7 +40,7 @@ module Json.Decode.Extra exposing
 
 # Dict
 
-@docs dict2
+@docs dict2, emptyObject
 
 
 # Maybe
@@ -163,6 +163,31 @@ decodeDictFromTuples keyDecoder tuples =
 
                 Err error ->
                     fail (errorToString error)
+
+
+{-| Succeed only when given an empty JSON object (`{}`).
+
+    import Json.Decode exposing (..)
+    import Json.Encode
+
+    decodeString emptyObject "{}"
+    --> Ok ()
+
+Anything else makes the decoder fail.
+
+-}
+emptyObject : Decoder ()
+emptyObject =
+    keyValuePairs (succeed ())
+        |> andThen
+            (\pairs ->
+                case pairs of
+                    [] ->
+                        succeed ()
+
+                    _ ->
+                        fail "Expecting an empty object"
+            )
 
 
 {-| Try running the given decoder; if that fails, then succeed with the given

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -168,7 +168,6 @@ decodeDictFromTuples keyDecoder tuples =
 {-| Succeed only when given an empty JSON object (`{}`).
 
     import Json.Decode exposing (..)
-    import Json.Encode
 
     decodeString emptyObject "{}"
     --> Ok ()


### PR DESCRIPTION
In my job, we've just encountered a situation where we need to decode an empty JSON object. There is a trick for it but not many people know it. So, let's give it a name and make it more discoverable?

EDIT: I tried to create a doctest for the `Err` case (ie. `decodeString emptyObject """{"foo": "bar"}""" --> Err (Failure "..." (Json.Encode.string "...")`) but there seems to be some issue with `Encode.Value` equality - couldn't make that work.