### PR TITLE
Add Json.Encode.Extra.at counterpart to Json.Decode.at

### DIFF
--- a/src/Json/Encode/Extra.elm
+++ b/src/Json/Encode/Extra.elm
@@ -1,4 +1,7 @@
-module Json.Encode.Extra exposing (maybe)
+module Json.Encode.Extra exposing
+    ( maybe
+    , at
+    )
 
 {-| Convenience functions for turning Elm values into Json values.
 
@@ -25,3 +28,26 @@ import Json.Encode exposing (Value, encode, int, null, object)
 maybe : (a -> Value) -> Maybe a -> Value
 maybe encoder =
     Maybe.map encoder >> Maybe.withDefault null
+
+
+{-| Decode a nested JSON object, requiring certain fields.
+
+    import Json.Encode exposing (..)
+
+    encodedValue : Json.Encode.Value
+    encodedValue =
+        (Json.Encode.string "Elm Street")
+
+    at [ "Nightmare", "At" ] encodedValue
+        |> Json.Encode.encode 0
+    --> "{\"Nightmare\":{\"At\":\"Elm Street\"}}"
+
+This is really just a shorthand for:
+
+    Json.Encode.object [ ( "Nightmare", Json.Encode.object [ ( "At", encodedValue ) ] ) ]
+        |> Json.Encode.encode 0
+
+-}
+at : List String -> Json.Encode.Value -> Json.Encode.Value
+at keys initial =
+    List.foldr (\k current -> Json.Encode.object [ ( k, current ) ]) initial keys


### PR DESCRIPTION
The standard elm/json has a nice function [Json.Decode.at](https://package.elm-lang.org/packages/elm/json/latest/Json-Decode#at)

``` elm
Json.Decode.at [ "Nightmare", "At" ] Json.Decode.string
```

This PR introduces the counterpart for encoding: `Json.Encode.Extra.at`

```elm
encodedValue = (Json.Encode.string "Elm Street")

Json.Encode.Extra.at [ "Nightmare", "At" ] encodedValue
-- {"Nightmare":{"At":"Elm Street"}}
```